### PR TITLE
all: fixup formatting and modernize procedure calls

### DIFF
--- a/generate.odin
+++ b/generate.odin
@@ -1,13 +1,13 @@
 package odin_win32_generator
 
-import "core:os"
-import "core:io"
 import "core:encoding/json"
 import "core:fmt"
+import "core:io"
+import "core:os"
 import "core:path/filepath"
 import "core:strings"
+import "core:sync"
 import "core:thread"
-import sync "core:sync/sync2"
 
 
 Api_Type_Name_To_Api_Ref_Map :: struct {
@@ -16,15 +16,14 @@ Api_Type_Name_To_Api_Ref_Map :: struct {
 }
 
 File :: struct {
-	pkg: ^Pkg,
+	pkg:       ^Pkg,
 	full_path: string,
 	base_path: string,
 	api:       string,
-	name: string,
-	data: []byte,
-	root: json.Value,
-
-	type_map: Api_Type_Name_To_Api_Ref_Map,
+	name:      string,
+	data:      []byte,
+	root:      json.Value,
+	type_map:  Api_Type_Name_To_Api_Ref_Map,
 }
 
 Api_Ref :: struct {
@@ -34,195 +33,184 @@ Api_Ref :: struct {
 
 
 Pkg :: struct {
-	name: string,
+	name:  string,
 	files: [dynamic]^File,
-	deps: map[^Pkg]bool,
+	deps:  map[^Pkg]bool,
 }
 
 
 Generator :: struct {
-	files: [dynamic]^File,
-	file_map: map[string]^File,
-	pkgs: map[string]^Pkg, // Key: package name
-
-	api_type_map: map[string]^Api_Type_Name_To_Api_Ref_Map,
-
-	full_type_set:      map[Api_Ref]bool,
-	api_cycle_type_set: map[Api_Ref][]Api_Ref,
-
-	api_to_file_map: map[string]^File,
-	api_to_pkg_map: map[string]^Pkg,
-	cycle_types: map[Api_Ref]json.Value,
-
-	type_in_pkg_types: map[string]bool,
-
+	files:                     [dynamic]^File,
+	file_map:                  map[string]^File,
+	pkgs:                      map[string]^Pkg, // Key: package name
+	api_type_map:              map[string]^Api_Type_Name_To_Api_Ref_Map,
+	full_type_set:             map[Api_Ref]bool,
+	api_cycle_type_set:        map[Api_Ref][]Api_Ref,
+	api_to_file_map:           map[string]^File,
+	api_to_pkg_map:            map[string]^Pkg,
+	cycle_types:               map[Api_Ref]json.Value,
+	type_in_pkg_types:         map[string]bool,
 	apis_not_needed_for_types: map[string]bool,
-
-	type_names_to_remove: map[Api_Ref]bool,
-
-	procedures_to_ignore: map[Api_Ref]bool,
+	type_names_to_remove:      map[Api_Ref]bool,
+	procedures_to_ignore:      map[Api_Ref]bool,
 }
 trim_at_first_dot :: proc(name: string) -> string {
-	n := strings.index_byte(name, '.');
+	n := strings.index_byte(name, '.')
 	if n < 0 {
-		n = len(name);
+		n = len(name)
 	}
-	return name[:n];
+	return name[:n]
 }
 
 get_api_name_from_file_name :: proc(name: string, allocator := context.allocator) -> string {
-	n := strings.last_index_byte(name, '.');
+	n := strings.last_index_byte(name, '.')
 	if n < 0 {
-		n = len(name);
+		n = len(name)
 	}
-	return name[:n];
+	return name[:n]
 }
 get_package_name_from_file_name :: proc(name: string, allocator := context.allocator) -> string {
-	n := strings.index_byte(name, '.');
+	n := strings.index_byte(name, '.')
 	if n < 0 {
-		n = len(name);
+		n = len(name)
 	}
-	return strings.to_snake_case(name[:n], allocator);
+	return strings.to_snake_case(name[:n], allocator)
 }
 
 is_anon_type :: proc(type_name: string) -> bool {
-	return strings.has_suffix(type_name, "_e__Struct") || strings.has_suffix(type_name, "_e__Union");
+	return(
+		strings.has_suffix(type_name, "_e__Struct") ||
+		strings.has_suffix(type_name, "_e__Union") \
+	)
 }
 
 get_api_ref_top_level_type :: proc(type_obj: json.Object) -> string {
-	parents := type_obj["Parents"];
+	parents := type_obj["Parents"]
 	if parents != nil {
 		if array, ok := parents.(json.Array); ok && len(array) != 0 {
-			return array[0].(string);
+			return array[0].(string)
 		}
 	}
-	return type_obj["Name"].(string);
+	return type_obj["Name"].(string)
 }
 
 get_json_api_refs :: proc(api_refs: ^map[Api_Ref]bool, json_obj: json.Value) {
 	switch v in json_obj {
 	case json.Object:
-			if name, _ := v["Kind"].(string); name == "ApiRef" {
-				key := Api_Ref{
-					api = v["Api"].(string),
-					name = get_api_ref_top_level_type(v),
-				};
-				api_refs[key] = true;
-				return;
+		if name, _ := v["Kind"].(string); name == "ApiRef" {
+			key := Api_Ref {
+				api  = v["Api"].(string),
+				name = get_api_ref_top_level_type(v),
 			}
-			for _, entry in v {
-				get_json_api_refs(api_refs, entry);
-			}
+			api_refs[key] = true
+			return
+		}
+		for _, entry in v {
+			get_json_api_refs(api_refs, entry)
+		}
 	case json.Array:
 		for entry in v {
-			get_json_api_refs(api_refs, entry);
+			get_json_api_refs(api_refs, entry)
 		}
 	case json.Null, string, i64, f64, bool:
-		// ignore
+	// ignore
 	}
 }
 
 get_nested_name :: proc(type_name: string, ref: Api_Ref) -> string {
-	type_names := strings.split(type_name, ".", context.temp_allocator);
-	ref_names  := strings.split(ref.name,  ".", context.temp_allocator);
-	i := 0;
+	type_names := strings.split(type_name, ".", context.temp_allocator)
+	ref_names := strings.split(ref.name, ".", context.temp_allocator)
+	i := 0
 	for i < len(ref_names) && i < len(type_names) {
-		if ref_names[i] != type_names[len(type_names)-i-1] {
-			break;
+		if ref_names[i] != type_names[len(type_names) - i - 1] {
+			break
 		}
-		i += 1;
+		i += 1
 	}
-	b: [dynamic]byte;
-	j := 0;
+	b: [dynamic]byte
+	j := 0
 	for n in type_names {
 		if j > 0 {
-			append(&b, '.');
+			append(&b, '.')
 		}
-		append(&b, n);
-		j += 1;
+		append(&b, n)
+		j += 1
 	}
 
 	for n in ref_names[i:] {
 		if j > 0 {
-			append(&b, '.');
+			append(&b, '.')
 		}
-		append(&b, n);
-		j += 1;
+		append(&b, n)
+		j += 1
 	}
 
-	return string(b[:]);
+	return string(b[:])
 }
 
-apis_to_ignore := []string{
-	"AI.",
-	"Data.",
-	"Web.",
-	"System.Diagnostics.Debug",
-};
+apis_to_ignore := []string{"AI.", "Data.", "Web.", "System.Diagnostics.Debug"}
 
 do_ignore_api :: proc(api: string) -> bool {
 	for i in apis_to_ignore {
 		if strings.has_prefix(api, i) {
-			return true;
+			return true
 		}
 	}
-	return false;
+	return false
 }
 
-functions_to_ignore := []Api_Ref{
-	{"System.TpmBaseServices", "GetDeviceID"},
-};
+functions_to_ignore := []Api_Ref{{"System.TpmBaseServices", "GetDeviceID"}}
 
 calculate_type_graph :: proc(g: ^Generator) {
 	Type_Node :: struct {
 		preds: map[Api_Ref]bool,
 		succs: map[Api_Ref]bool,
-	};
-	Type_Graph :: map[Api_Ref]^Type_Node;
+	}
+	Type_Graph :: map[Api_Ref]^Type_Node
 
-	graph: Type_Graph;
-	defer delete(graph);
+	graph: Type_Graph
+	defer delete(graph)
 
 
 	for file in g.files {
-		table := &file.type_map;
+		table := &file.type_map
 		for type_name, refs in table.top_level {
-			type_ref := Api_Ref{file.api, type_name};
-			node := new(Type_Node);
-			node.succs = refs;
-			graph[type_ref] = node;
+			type_ref := Api_Ref{file.api, type_name}
+			node := new(Type_Node)
+			node.succs = refs
+			graph[type_ref] = node
 		}
 		for type_name, refs in table.nested {
-			type_ref := Api_Ref{file.api, type_name};
-			node := new(Type_Node);
-			node.succs = refs;
-			graph[type_ref] = node;
+			type_ref := Api_Ref{file.api, type_name}
+			node := new(Type_Node)
+			node.succs = refs
+			graph[type_ref] = node
 		}
 	}
 
 	for file in g.files {
-		table := &file.type_map;
+		table := &file.type_map
 		for type_name, refs in table.top_level {
-			type_ref := Api_Ref{file.api, type_name};
-			node := graph[type_ref];
-			assert(node != nil);
+			type_ref := Api_Ref{file.api, type_name}
+			node := graph[type_ref]
+			assert(node != nil)
 			for succ in node.succs {
-				succ_node := graph[succ];
+				succ_node := graph[succ]
 				if succ_node != nil {
-					fmt.assertf(succ_node != nil, "%v", succ);
-					succ_node.preds[type_ref] = true;
+					fmt.assertf(succ_node != nil, "%v", succ)
+					succ_node.preds[type_ref] = true
 				}
 			}
 		}
 		for type_name, refs in table.nested {
-			type_ref := Api_Ref{file.api, type_name};
-			node := graph[type_ref];
-			assert(node != nil);
+			type_ref := Api_Ref{file.api, type_name}
+			node := graph[type_ref]
+			assert(node != nil)
 			for succ in node.succs {
-				succ_node := graph[succ];
+				succ_node := graph[succ]
 				if succ_node != nil {
-					fmt.assertf(succ_node != nil, "%v", succ);
-					succ_node.preds[type_ref] = true;
+					fmt.assertf(succ_node != nil, "%v", succ)
+					succ_node.preds[type_ref] = true
 				}
 			}
 		}
@@ -230,189 +218,200 @@ calculate_type_graph :: proc(g: ^Generator) {
 
 	for type_ref, node in graph {
 		if len(node.preds) == 0 {
-			g.type_names_to_remove[type_ref] = true;
+			g.type_names_to_remove[type_ref] = true
 		}
 	}
 
-	fmt.println("TYPE GRAPH DONE");
+	fmt.println("TYPE GRAPH DONE")
 }
 
 main :: proc() {
-	defer fmt.println("[Done]");
+	defer fmt.println("[Done]")
 
-	g := &Generator{};
+	g := &Generator{}
 
-	filepaths, err := filepath.glob("win32json/api/*.json");
-	assert(err == nil);
+	filepaths, err := filepath.glob("win32json/api/*.json")
+	assert(err == nil)
 
-	total_file_data_size := 0;
+	total_file_data_size := 0
 
-	fmt.println("[Collect Files]");
+	fmt.println("[Collect Files]")
 	// Collect file
 	for path in filepaths {
-		filename := filepath.base(path);
-		base_path := filename;
-		filename = filename[:strings.last_index_byte(filename, '.')];
+		filename := filepath.base(path)
+		base_path := filename
+		filename = filename[:strings.last_index_byte(filename, '.')]
 		if n := strings.index_byte(filename, '.'); n >= 0 {
-			filename = filename[n+1:];
+			filename = filename[n + 1:]
 		}
-		filename, _ = strings.replace_all(filename, ".", "_");
-		filename = strings.to_snake_case(filename);
+		filename, _ = strings.replace_all(filename, ".", "_")
+		filename = strings.to_snake_case(filename)
 
 		if do_ignore_api(base_path) {
-			continue;
+			continue
 		}
 
-		data, ok := os.read_entire_file(path);
-		assert(ok);
+		data, ok := os.read_entire_file(path)
+		assert(ok)
 
-		total_file_data_size += len(data);
+		total_file_data_size += len(data)
 
-		append(&g.files, new_clone(File{
-			full_path = path,
-			base_path = base_path,
-			name = filename,
-			data = data,
-		}));
+		append(
+			&g.files,
+			new_clone(File{full_path = path, base_path = base_path, name = filename, data = data}),
+		)
 	}
 
 	// Sort files into packages
 	for file in g.files {
-		pkg_name := get_package_name_from_file_name(file.base_path, context.temp_allocator);
+		pkg_name := get_package_name_from_file_name(file.base_path, context.temp_allocator)
 
-		pkg, pkg_exists := g.pkgs[pkg_name];
+		pkg, pkg_exists := g.pkgs[pkg_name]
 		if !pkg_exists {
-			pkg = new(Pkg);
-			pkg.name = pkg_name;
-			g.pkgs[strings.clone(pkg_name)] = pkg;
+			pkg = new(Pkg)
+			pkg.name = pkg_name
+			g.pkgs[strings.clone(pkg_name)] = pkg
 		}
-		file.pkg = pkg;
-		append(&pkg.files, file);
+		file.pkg = pkg
+		append(&pkg.files, file)
 
-		file.api = get_api_name_from_file_name(file.base_path);
-		g.api_type_map[file.api] = &file.type_map;
-		g.api_to_file_map[file.api] = file;
-		g.api_to_pkg_map[file.api] = pkg;
+		file.api = get_api_name_from_file_name(file.base_path)
+		g.api_type_map[file.api] = &file.type_map
+		g.api_to_file_map[file.api] = file
+		g.api_to_pkg_map[file.api] = pkg
 	}
 
-	fmt.println("[Parse Files]");
+	fmt.println("[Parse Files]")
 
-	@static wg: sync.Wait_Group;
+	@(static)
+	wg: sync.Wait_Group
 
 	// Thread pool? Who needs that? ;)
-	sync.wait_group_add(&wg, len(g.files));
+	sync.wait_group_add(&wg, len(g.files))
 	for file in g.files {
-		thread.run_with_poly_data(file, proc(file: ^File) {
-			root, err := json.parse(file.data, .JSON, /*parse integers*/true);
-			if err != nil {
-				fmt.eprintf("Error parsing file %s: %v\n", file.full_path, err);
-				os.exit(1);
-			}
-			file.root = root;
-			sync.wait_group_done(&wg);
-		});
+		thread.run_with_poly_data(
+			file,
+			proc(file: ^File) {
+				root, err := json.parse(
+					file.data,
+					.JSON,
+					/*parse integers*/
+					true,
+				)
+				if err != nil {
+					fmt.eprintf("Error parsing file %s: %v\n", file.full_path, err)
+					os.exit(1)
+				}
+				file.root = root
+				sync.wait_group_done(&wg)
+			},
+		)
 	}
-	sync.wait_group_wait(&wg);
+	sync.wait_group_wait(&wg)
 
-	fmt.println("[Loading Types]");
+	fmt.println("[Loading Types]")
 
 	for file in g.files {
-		add_type_refs :: proc(type_map: ^Api_Type_Name_To_Api_Ref_Map, name_prefix: string, type_json: json.Value) {
-			type_obj := type_json.(json.Object);
-			kind := type_obj["Kind"].(string);
-			name := type_obj["Name"].(string);
-			full_name := strings.concatenate({name_prefix, name});
+		add_type_refs :: proc(
+			type_map: ^Api_Type_Name_To_Api_Ref_Map,
+			name_prefix: string,
+			type_json: json.Value,
+		) {
+			type_obj := type_json.(json.Object)
+			kind := type_obj["Kind"].(string)
+			name := type_obj["Name"].(string)
+			full_name := strings.concatenate({name_prefix, name})
 
-			api_refs: map[Api_Ref]bool;
+			api_refs: map[Api_Ref]bool
 			switch kind {
 			case "Struct", "Union":
-				get_json_api_refs(&api_refs, type_obj["Fields"]);
-				nested_types, _ := type_obj["NestedTypes"].(json.Array);
+				get_json_api_refs(&api_refs, type_obj["Fields"])
+				nested_types, _ := type_obj["NestedTypes"].(json.Array)
 				for nested_type in nested_types {
-					add_type_refs(type_map, strings.concatenate({full_name, "."}), nested_type);
+					add_type_refs(type_map, strings.concatenate({full_name, "."}), nested_type)
 				}
 			case "Enum", "ComClassID":
-				get_json_api_refs(&api_refs, type_json);
-				assert(len(api_refs) == 0);
+				get_json_api_refs(&api_refs, type_json)
+				assert(len(api_refs) == 0)
 			case "Com", "FunctionPointer", "NativeTypedef":
-				get_json_api_refs(&api_refs, type_json);
+				get_json_api_refs(&api_refs, type_json)
 			case:
-				panic(kind);
+				panic(kind)
 			}
 
-			table: ^map[string]map[Api_Ref]bool;
-			table = &type_map.top_level;
+			table: ^map[string]map[Api_Ref]bool
+			table = &type_map.top_level
 			if len(name_prefix) != 0 {
-				table = &type_map.nested;
+				table = &type_map.nested
 			}
 
 			if full_name in table^ {
-				t := &table[full_name];
+				t := &table[full_name]
 				for k, v in api_refs {
-					t[k] = v;
+					t[k] = v
 				}
 			} else {
-				table[full_name] = api_refs;
+				table[full_name] = api_refs
 			}
 		}
 
-		root := file.root.(json.Object);
-		types := root["Types"].(json.Array);
+		root := file.root.(json.Object)
+		types := root["Types"].(json.Array)
 		for type in types {
-			add_type_refs(&file.type_map, "", type);
+			add_type_refs(&file.type_map, "", type)
 		}
 	}
 
-	fmt.println("[Check Type Refs Exist]");
+	fmt.println("[Check Type Refs Exist]")
 
 	for file in g.files {
-		i := 0;
+		i := 0
 		for type_name, refs in file.type_map.top_level {
-			i += 1;
+			i += 1
 			if len(refs) == 0 {
-				continue;
+				continue
 			}
 
 			for ref in refs {
 				if do_ignore_api(ref.api) {
 					// fmt.println(file.api, type_name);
-					g.type_names_to_remove[{file.api, type_name}] = true;
-					continue;
+					g.type_names_to_remove[{file.api, type_name}] = true
+					continue
 				}
 				if !is_anon_type(ref.name) {
-					table := g.api_type_map[ref.api];
-					fmt.assertf(table != nil, "%s needed by %s", ref.api, type_name);
+					table := g.api_type_map[ref.api]
+					fmt.assertf(table != nil, "%s needed by %s", ref.api, type_name)
 					if ref.name not_in table.top_level {
-						nested_name := get_nested_name(type_name, ref);
-						defer delete(nested_name);
-						assert(nested_name in table.nested, "nested_name not found");
+						nested_name := get_nested_name(type_name, ref)
+						defer delete(nested_name)
+						assert(nested_name in table.nested, "nested_name not found")
 					}
 				}
 			}
 		}
 	}
 
-	fmt.println("[Calculate Entity Count]");
-	total_const_count := 0;
-	total_type_count := 0;
-	total_proc_count := 0;
+	fmt.println("[Calculate Entity Count]")
+	total_const_count := 0
+	total_type_count := 0
+	total_proc_count := 0
 	for file in g.files {
-		root := file.root.(json.Object);
-		constants, _ := root["Constants"].(json.Array);
-		types    , _ := root["Types"].(json.Array);
-		functions, _ := root["Functions"].(json.Array);
-		total_const_count += len(constants);
-		total_type_count  += len(types);
-		total_proc_count  += len(functions);
+		root := file.root.(json.Object)
+		constants, _ := root["Constants"].(json.Array)
+		types, _ := root["Types"].(json.Array)
+		functions, _ := root["Functions"].(json.Array)
+		total_const_count += len(constants)
+		total_type_count += len(types)
+		total_proc_count += len(functions)
 
 	}
-	fmt.println("[Constant  Max Count]", total_const_count);
-	fmt.println("[Type      Max Count]", total_type_count);
-	fmt.println("[Procedure Max Count]", total_proc_count);
+	fmt.println("[Constant  Max Count]", total_const_count)
+	fmt.println("[Type      Max Count]", total_type_count)
+	fmt.println("[Procedure Max Count]", total_proc_count)
 
-	fmt.println("[Calculate Type References]");
-	api_recursive_type_refs_table_pkg: map[^Pkg]map[string][dynamic][]Api_Ref;
-	api_recursive_type_refs_table_api: map[string]map[string][dynamic][]Api_Ref;
+	fmt.println("[Calculate Type References]")
+	api_recursive_type_refs_table_pkg: map[^Pkg]map[string][dynamic][]Api_Ref
+	api_recursive_type_refs_table_api: map[string]map[string][dynamic][]Api_Ref
 
 	for file in g.files {
 		get_recursive_chains :: proc(
@@ -424,98 +423,99 @@ main :: proc() {
 			base_chain: []Api_Ref,
 		) {
 			for ref in refs {
-				table := g.api_type_map[ref.api];
+				table := g.api_type_map[ref.api]
 				if table == nil {
-					continue;
+					continue
 				}
 				if ref in g.type_names_to_remove {
-					continue;
+					continue
 				}
 				if !is_anon_type(ref.name) && ref.name in table.top_level {
-					next_chain := make([]Api_Ref, len(base_chain)+1);
-					copy(next_chain, base_chain);
-					next_chain[len(base_chain)] = ref;
+					next_chain := make([]Api_Ref, len(base_chain) + 1)
+					copy(next_chain, base_chain)
+					next_chain[len(base_chain)] = ref
 
-					ref_refs := table.top_level[ref.name];
+					ref_refs := table.top_level[ref.name]
 					if len(ref_refs) == 0 || ref in handled^ {
-						append(result, next_chain);
+						append(result, next_chain)
 					} else {
-						handled[ref] = true;
-						get_recursive_chains(g, table, handled, ref_refs, result, next_chain);
+						handled[ref] = true
+						get_recursive_chains(g, table, handled, ref_refs, result, next_chain)
 					}
 				}
 			}
 		}
 
-		handled: map[Api_Ref]bool;
-		defer delete(handled);
+		handled: map[Api_Ref]bool
+		defer delete(handled)
 
-		recursive_type_refs_table: map[string][dynamic][]Api_Ref;
+		recursive_type_refs_table: map[string][dynamic][]Api_Ref
 
-		table := &file.type_map;
+		table := &file.type_map
 		for type_name, refs in table.top_level {
 			if (Api_Ref{file.api, type_name} in g.type_names_to_remove) {
-				continue;
+				continue
 			}
 
-			clear(&handled);
-			recursive_chains: [dynamic][]Api_Ref;
-			get_recursive_chains(g, table, &handled, refs, &recursive_chains, nil);
+			clear(&handled)
+			recursive_chains: [dynamic][]Api_Ref
+			get_recursive_chains(g, table, &handled, refs, &recursive_chains, nil)
 
-			recursive_type_refs_table[type_name] = recursive_chains;
+			recursive_type_refs_table[type_name] = recursive_chains
 		}
 
 		if file.pkg not_in api_recursive_type_refs_table_pkg {
-			api_recursive_type_refs_table_pkg[file.pkg] = make(map[string][dynamic][]Api_Ref);
+			api_recursive_type_refs_table_pkg[file.pkg] = make(map[string][dynamic][]Api_Ref)
 		}
-		prev, _ := &api_recursive_type_refs_table_pkg[file.pkg];
+		prev, _ := &api_recursive_type_refs_table_pkg[file.pkg]
 		for k, v in recursive_type_refs_table {
-			prev[k] = v;
+			prev[k] = v
 		}
 
-		api_recursive_type_refs_table_api[file.api] = recursive_type_refs_table;
+		api_recursive_type_refs_table_api[file.api] = recursive_type_refs_table
 	}
 
-	fmt.println("[Calculate Package Dependency Graph]");
+	fmt.println("[Calculate Package Dependency Graph]")
 	for pkg, m in api_recursive_type_refs_table_pkg {
 		for type_name, refs_da in m do for refs in refs_da {
 			for ref in refs {
-				other_pkg := g.api_to_pkg_map[ref.api];
+				other_pkg := g.api_to_pkg_map[ref.api]
 				if other_pkg != nil && other_pkg != pkg {
-					pkg.deps[other_pkg] = true;
+					pkg.deps[other_pkg] = true
 				}
 			}
 		}
 	}
 
-	fmt.println("[Calculate Procedure References]");
+	fmt.println("[Calculate Procedure References]")
 	for file in g.files {
-		file_obj := file.root.(json.Object);
-		functions, _ := file_obj["Functions"].(json.Array);
+		file_obj := file.root.(json.Object)
+		functions, _ := file_obj["Functions"].(json.Array)
 		func_loop: for func in functions {
-			obj := func.(json.Object);
-			name := obj["Name"].(string);
+			obj := func.(json.Object)
+			name := obj["Name"].(string)
 
-			proc_ref := Api_Ref{file.api, name};
+			proc_ref := Api_Ref{file.api, name}
 
-			refs: map[Api_Ref]bool;
-			defer delete(refs);
-			get_json_api_refs(&refs, obj["ReturnType"]);
-			get_json_api_refs(&refs, obj["Params"]);
+			refs: map[Api_Ref]bool
+			defer delete(refs)
+			get_json_api_refs(&refs, obj["ReturnType"])
+			get_json_api_refs(&refs, obj["Params"])
 			for ref in refs {
 				if do_ignore_api(ref.api) || ref in g.type_names_to_remove {
 					// fmt.printf("\tIgnoring Procedure: %s %s\n", proc_ref.api, proc_ref.name);
-					g.procedures_to_ignore[proc_ref] = true;
-					continue func_loop;
+					g.procedures_to_ignore[proc_ref] = true
+					continue func_loop
 				}
 			}
 		}
 	}
 
 	for proc_ref in functions_to_ignore {
-		g.procedures_to_ignore[proc_ref] = true;
+		g.procedures_to_ignore[proc_ref] = true
 	}
 
-	// fmt.println("[Writing Package Files]");
-	// write_to_odin(g);
+	fmt.println("[Writing Package Files]")
+	write_to_odin(g)
 }
+

--- a/writer.odin
+++ b/writer.odin
@@ -5,12 +5,12 @@ import "core:fmt"
 import "core:io"
 import "core:os"
 import "core:slice"
-import "core:strings"
 import "core:strconv"
+import "core:strings"
 
 
-BUILTIN_PKG :: "_builtin";
-TYPES_PKG :: "_types";
+BUILTIN_PKG :: "_builtin"
+TYPES_PKG :: "_types"
 
 Grouped_Procedures :: struct {
 	dll_import: string,
@@ -18,31 +18,25 @@ Grouped_Procedures :: struct {
 }
 
 File_Generator :: struct {
-	g: ^Generator,
-	fd: os.Handle,
-	b: ^strings.Builder,
-	file: ^File,
-	fullpath: string,
-
-	imports: map[string]bool,
-	foreign_imports: map[string]string, // Key: lib, Value: identifier
-	procedures: map[string]^Grouped_Procedures, // Key: DLL Import
-	ignore_imports: bool,
-	is_types_pkg: bool,
-
-	disallow_maybe: bool,
-
-	all_decls: ^map[string]bool,
-
-	depth: int,
-	nested_types: json.Array,
-
+	g:                     ^Generator,
+	fd:                    os.Handle,
+	b:                     ^strings.Builder,
+	file:                  ^File,
+	fullpath:              string,
+	imports:               map[string]bool,
+	foreign_imports:       map[string]string, // Key: lib, Value: identifier
+	procedures:            map[string]^Grouped_Procedures, // Key: DLL Import
+	ignore_imports:        bool,
+	is_types_pkg:          bool,
+	disallow_maybe:        bool,
+	all_decls:             ^map[string]bool,
+	depth:                 int,
+	nested_types:          json.Array,
 	nested_types_to_print: [dynamic]json.Value,
-
-	missing_clr_types: ^map[string]json.Object,
+	missing_clr_types:     ^map[string]json.Object,
 }
 
-odin_keywords := map[string]string{
+odin_keywords := map[string]string {
 	"auto_cast"   = "auto_cast_",
 	"bit_set"     = "bit_set_",
 	"cast"        = "cast_",
@@ -61,62 +55,74 @@ odin_keywords := map[string]string{
 	"where"       = "where_",
 
 	// other special things
-
 	"Node"        = "node",
-};
+}
 
 
 value_type_to_odin_type :: proc(value: string) -> string {
 	switch value {
-	case "Byte":        return "u8";
-        case "UInt16":      return "u16";
-        case "Int32":       return "i32";
-        case "UInt32":      return "u32";
-        case "Int64":       return "i64";
-        case "UInt64":      return "u64";
-        case "Single":      return "f32";
-        case "Double":      return "f64";
-        case "String":      return "string";
-        case "PropertyKey":
-        	panic("cannot call value_type_to_odin_type for \"PropertyKey\"");
+	case "Byte":
+		return "u8"
+	case "UInt16":
+		return "u16"
+	case "Int32":
+		return "i32"
+	case "UInt32":
+		return "u32"
+	case "Int64":
+		return "i64"
+	case "UInt64":
+		return "u64"
+	case "Single":
+		return "f32"
+	case "Double":
+		return "f64"
+	case "String":
+		return "string"
+	case "PropertyKey":
+		panic("cannot call value_type_to_odin_type for \"PropertyKey\"")
 	}
-	fmt.panicf("unknown value %s", value);
+	fmt.panicf("unknown value %s", value)
 }
 
 
 write_constant :: proc(fg: ^File_Generator, w: io.Writer, constant: json.Value) {
-	obj := constant.(json.Object);
-	name := obj["Name"].(string);
-	value_type, _ := obj["ValueType"].(string);
+	obj := constant.(json.Object)
+	name := obj["Name"].(string)
+	value_type, _ := obj["ValueType"].(string)
 
 	if value_type == "PropertyKey" {
 		// TODO(bill): GUID shit
-		return;
+		return
 	}
 
 	if name == "INVALID_HANDLE_VALUE" {
-		fmt.wprintf(w, "%s :: HANDLE(~uintptr(0));\n", name);
-		return;
+		fmt.wprintf(w, "%s :: HANDLE(~uintptr(0));\n", name)
+		return
 	}
 	switch v in obj["Value"] {
 	case i64, f64, bool:
-		fmt.wprintf(w, "%s :: %v;\n", name, v);
+		fmt.wprintf(w, "%s :: %v;\n", name, v)
 	case string:
-		fmt.wprintf(w, "%s :: %q;\n", name, v);
+		fmt.wprintf(w, "%s :: %q;\n", name, v)
 
 	case json.Array, json.Object, json.Null:
-		fmt.panicf("%s: %v", fg.file.name, v);
+		fmt.panicf("%s: %v", fg.file.name, v)
 	}
 }
 
-Record_Kind :: enum {None, Struct, Union};
+Record_Kind :: enum {
+	None,
+	Struct,
+	Union,
+}
 get_anon_kind :: proc(s: string) -> Record_Kind {
 	if strings.has_suffix(s, "_e__Struct") {
-		return .Struct;
+		return .Struct
 	} else if strings.has_suffix(s, "_e__Union") {
-		return .Union;
+		return .Union
 	}
-	return .None;
+	return .None
 }
 
 Field_Option :: enum {
@@ -132,7 +138,7 @@ Field_Option :: enum {
 	Obsolete,
 }
 
-Field_Options :: distinct bit_set[Field_Option];
+Field_Options :: distinct bit_set[Field_Option]
 
 parse_field_options :: proc(field_attrs: json.Array) -> (field_options: Field_Options) {
 	for attr_obj in field_attrs {
@@ -140,23 +146,27 @@ parse_field_options :: proc(field_attrs: json.Array) -> (field_options: Field_Op
 		case string:
 			switch attr {
 			case "Const":
-				field_options += {.Const};
+				field_options += {.Const}
 			case "NotNullTerminated":
-				field_options += {.Not_Null_Terminated};
+				field_options += {.Not_Null_Terminated}
 			case "NullNullTerminated":
-				field_options += {.Is_Null_Terminated};
-			case "Obselete": // This is a typo in the win32json generation
-				field_options += {.Obsolete};
+				field_options += {.Is_Null_Terminated}
+			case "Obselete":
+				// This is a typo in the win32json generation
+				field_options += {.Obsolete}
 			case "Optional":
-				field_options += {.Optional};
+				field_options += {.Optional}
 			}
 		}
 	}
-	return;
+	return
 }
 
 Depth_Kind :: enum {
-	Top_Level, Child, Array, Return,
+	Top_Level,
+	Child,
+	Array,
+	Return,
 }
 
 Target_Kind :: enum {
@@ -169,478 +179,498 @@ add_import :: proc(fg: ^File_Generator, import_path: string) -> bool {
 	if fg.ignore_imports {
 		switch import_path {
 		case "core:c", BUILTIN_PKG:
-			// Okay
+		// Okay
 		case:
-			return false;
+			return false
 		}
 	}
 	if fg.file.pkg.name != import_path {
-		fg.imports[import_path] = true;
-		return true;
+		fg.imports[import_path] = true
+		return true
 	}
-	return false;
+	return false
 }
 
-write_type_ref :: proc(fg: ^File_Generator, w: io.Writer, obj: json.Object, field_options: Field_Options, depth_kind := Depth_Kind.Top_Level) {
-	kind := obj["Kind"].(string);
+write_type_ref :: proc(
+	fg: ^File_Generator,
+	w: io.Writer,
+	obj: json.Object,
+	field_options: Field_Options,
+	depth_kind := Depth_Kind.Top_Level,
+) {
+	kind := obj["Kind"].(string)
 	switch kind {
 	case "Native":
-		name := obj["Name"].(string);
-		assert(name != "Void");
+		name := obj["Name"].(string)
+		assert(name != "Void")
 		switch name {
 		case "Boolean":
-			io.write_string(w, "bool");
+			io.write_string(w, "bool")
 		case "SByte":
-			io.write_string(w, "i8");
+			io.write_string(w, "i8")
 		case "Byte":
-			io.write_string(w, "u8");
+			io.write_string(w, "u8")
 		case "Int16":
-			io.write_string(w, "i16");
+			io.write_string(w, "i16")
 		case "UInt16":
-			io.write_string(w, "u16");
+			io.write_string(w, "u16")
 		case "Int32":
-			io.write_string(w, "i32");
+			io.write_string(w, "i32")
 		case "UInt32":
-			io.write_string(w, "u32");
+			io.write_string(w, "u32")
 		case "Int64":
-			io.write_string(w, "i64");
+			io.write_string(w, "i64")
 		case "UInt64":
-			io.write_string(w, "u64");
+			io.write_string(w, "u64")
 		case "Char":
-			io.write_string(w, "u16");
+			io.write_string(w, "u16")
 		case "Single":
-			io.write_string(w, "f32");
+			io.write_string(w, "f32")
 		case "Double":
-			io.write_string(w, "f64");
+			io.write_string(w, "f64")
 		case "IntPtr":
-			io.write_string(w, "int");
+			io.write_string(w, "int")
 		case "UIntPtr":
-			io.write_string(w, "uintptr");
+			io.write_string(w, "uintptr")
 		case "Guid":
 			if add_import(fg, BUILTIN_PKG) {
-				io.write_string(w, BUILTIN_PKG);
-				io.write_byte(w, '.');
+				io.write_string(w, BUILTIN_PKG)
+				io.write_byte(w, '.')
 			}
-			io.write_string(w, "GUID");
+			io.write_string(w, "GUID")
 		case:
-			io.write_string(w, name);
+			io.write_string(w, name)
 		}
 
 	case "ApiRef":
-		name := obj["Name"].(string);
-		api := obj["Api"].(string);
+		name := obj["Name"].(string)
+		api := obj["Api"].(string)
 
 		switch kind := get_anon_kind(name); kind {
 		case .Struct, .Union:
-			assert(len(fg.nested_types) != 0);
+			assert(len(fg.nested_types) != 0)
 			for nested_type_value in fg.nested_types {
-				nested_type := nested_type_value.(json.Object);
+				nested_type := nested_type_value.(json.Object)
 				if nested_type["Name"].(string) == name {
-					write_struct_or_union(fg, w, nested_type, name, kind);
-					return;
+					write_struct_or_union(fg, w, nested_type, name, kind)
+					return
 				}
 			}
-			panic(name);
+			panic(name)
 		case .None:
 		}
 
-		target_kind: Target_Kind;
+		target_kind: Target_Kind
 		switch obj["TargetKind"].(string) {
-		case "Default":         target_kind = .Default;
-		case "FunctionPointer": target_kind = .Function_Pointer;
-		case "Com":             target_kind = .Com;
+		case "Default":
+			target_kind = .Default
+		case "FunctionPointer":
+			target_kind = .Function_Pointer
+		case "Com":
+			target_kind = .Com
 		}
 
-		parents := obj["Parents"].(json.Array);
+		parents := obj["Parents"].(json.Array)
 
-		is_maybe := false;
+		is_maybe := false
 		if .Direct_Type_Access not_in field_options {
 			if .Optional in field_options {
 				switch name {
 				case "LPARAM", "WPARAM":
-					is_maybe = false;
+					is_maybe = false
 				case:
-					is_maybe = true;
+					is_maybe = true
 				}
 			}
 
 			if is_maybe && !fg.disallow_maybe {
-				io.write_string(w, "Maybe(");
+				io.write_string(w, "Maybe(")
 			}
 
 			if target_kind == .Com {
-				io.write_string(w, "^");
+				io.write_string(w, "^")
 			}
 		}
 		defer if is_maybe && !fg.disallow_maybe {
-			io.write_string(w, ")");
+			io.write_string(w, ")")
 		}
 
 		switch name {
 		case "PSTR":
-			io.write_string(w, "cstring");
-			return;
+			io.write_string(w, "cstring")
+			return
 		case "PWSTR":
-			io.write_string(w, "^u16");
-			return;
+			io.write_string(w, "^u16")
+			return
 		}
 
-		api_ref := Api_Ref{api, name};
-		api_ref_pkg := fg.g.api_to_pkg_map[api];
-		fmt.assertf(api_ref_pkg != nil, "%v", api);
+		api_ref := Api_Ref{api, name}
+		api_ref_pkg := fg.g.api_to_pkg_map[api]
+		fmt.assertf(api_ref_pkg != nil, "%v", api)
 
 		if !fg.is_types_pkg && add_import(fg, TYPES_PKG) {
-			fmt.wprintf(w, "%s.", TYPES_PKG);
+			fmt.wprintf(w, "%s.", TYPES_PKG)
 		}
-		io.write_string(w, name);
+		io.write_string(w, name)
 
 
 	case "PointerTo":
-		child := obj["Child"].(json.Object);
-		child_options := field_options - {.Optional};
+		child := obj["Child"].(json.Object)
+		child_options := field_options - {.Optional}
 		if .Optional in field_options && !fg.disallow_maybe {
-			io.write_string(w, "Maybe(");
+			io.write_string(w, "Maybe(")
 		}
 
 		if name, _ := child["Name"].(string); name == "Void" {
-			io.write_string(w, "rawptr");
+			io.write_string(w, "rawptr")
 		} else {
-			io.write_string(w, "^");
+			io.write_string(w, "^")
 
-			child_options -= {.Const};
-			write_type_ref(fg, w, child, child_options, .Child);
+			child_options -= {.Const}
+			write_type_ref(fg, w, child, child_options, .Child)
 		}
 
-		if .Optional in field_options && !fg.disallow_maybe{
-			io.write_string(w, ")");
+		if .Optional in field_options && !fg.disallow_maybe {
+			io.write_string(w, ")")
 		}
 
 	case "Array":
-		child := obj["Child"].(json.Object);
-		array_len := i64(1);
+		child := obj["Child"].(json.Object)
+		array_len := i64(1)
 		#partial switch ss in obj["Shape"] {
 		case json.Object:
-			array_len = ss["Size"].(i64);
+			array_len = ss["Size"].(i64)
 		case json.Null:
-			array_len = 1;
+			array_len = 1
 		case:
-			panic("Invalid Array Size");
+			panic("Invalid Array Size")
 		}
-		fmt.wprintf(w, "[%d]", array_len);
-		write_type_ref(fg, w, child, field_options, .Child);
+		fmt.wprintf(w, "[%d]", array_len)
+		write_type_ref(fg, w, child, field_options, .Child)
 
 	case "LPArray":
-		child := obj["Child"].(json.Object);
+		child := obj["Child"].(json.Object)
 		if name, _ := child["Name"].(string); name == "Void" {
-			io.write_string(w, "rawptr");
+			io.write_string(w, "rawptr")
 		} else if name == "Char" {
-			io.write_string(w, "[^]u16");
+			io.write_string(w, "[^]u16")
 		} else if name == "Byte" {
-			io.write_string(w, "[^]u8");
+			io.write_string(w, "[^]u8")
 		} else {
-			child_options := field_options - {.Optional, .Const};
-			write_type_ref(fg, w, child, child_options, .Child);
+			child_options := field_options - {.Optional, .Const}
+			write_type_ref(fg, w, child, child_options, .Child)
 		}
 
 	case "MissingClrType":
-		name := obj["Name"].(string);
+		name := obj["Name"].(string)
 		if fg.missing_clr_types != nil && name not_in fg.missing_clr_types^ {
-			fg.missing_clr_types[name] = obj;
+			fg.missing_clr_types[name] = obj
 		}
 
 		if add_import(fg, BUILTIN_PKG) {
-			io.write_string(w, BUILTIN_PKG);
-			io.write_byte(w, '.');
+			io.write_string(w, BUILTIN_PKG)
+			io.write_byte(w, '.')
 		}
-		io.write_string(w, name);
-		// fmt.panicf("%s -> %v", kind, obj["Name"]);
+		io.write_string(w, name)
+	// fmt.panicf("%s -> %v", kind, obj["Name"]);
 	case:
-		panic(kind);
+		panic(kind)
 	}
 }
 write_indent :: proc(fg: ^File_Generator, w: io.Writer) {
-	for i in 0..<fg.depth {
-		io.write_byte(w, '\t');
+	for i in 0 ..< fg.depth {
+		io.write_byte(w, '\t')
 	}
 }
 
 is_field_anon :: proc(field: json.Object) -> bool {
-	field_type := field["Type"].(json.Object);
-	name, _ := field_type["Name"].(string);
+	field_type := field["Type"].(json.Object)
+	name, _ := field_type["Name"].(string)
 	if get_anon_kind(name) != .None {
-		return strings.has_prefix(name, "Anonymous");
+		return strings.has_prefix(name, "Anonymous")
 	}
-	return false;
+	return false
 }
 
-write_struct_or_union :: proc(fg: ^File_Generator, w: io.Writer, obj: json.Object, name: string, kind: Record_Kind) {
-	assert(name != "");
-	arches, _ := obj["Architectures"].(json.Object);
+write_struct_or_union :: proc(
+	fg: ^File_Generator,
+	w: io.Writer,
+	obj: json.Object,
+	name: string,
+	kind: Record_Kind,
+) {
+	assert(name != "")
+	arches, _ := obj["Architectures"].(json.Object)
 
-	struct_size, _ := obj["Size"].(i64);
-	struct_packing_size, _ := obj["PackingSize"].(i64);
-	struct_fields, _ := obj["Fields"].(json.Array);
-	struct_nested_types, _ := obj["NestedTypes"].(json.Array);
+	struct_size, _ := obj["Size"].(i64)
+	struct_packing_size, _ := obj["PackingSize"].(i64)
+	struct_fields, _ := obj["Fields"].(json.Array)
+	struct_nested_types, _ := obj["NestedTypes"].(json.Array)
 
-	prev_nested_types := fg.nested_types;
-	defer fg.nested_types = prev_nested_types;
+	prev_nested_types := fg.nested_types
+	defer fg.nested_types = prev_nested_types
 
-	fg.nested_types = struct_nested_types;
+	fg.nested_types = struct_nested_types
 
 	for nested_type in fg.nested_types {
-		append(&fg.nested_types_to_print, nested_type);
+		append(&fg.nested_types_to_print, nested_type)
 	}
 
 
 	if struct_size != 0 {
-		assert(len(struct_fields) != 0, name);
+		assert(len(struct_fields) != 0, name)
 	}
 
-	is_packed := struct_packing_size == 1;
+	is_packed := struct_packing_size == 1
 
-	io.write_string(w, "struct ");
+	io.write_string(w, "struct ")
 	if kind == .Union {
-		io.write_string(w, "#raw_union ");
+		io.write_string(w, "#raw_union ")
 	} else if struct_packing_size == 1 {
-		io.write_string(w, "#packed ");
+		io.write_string(w, "#packed ")
 	}
-	io.write_string(w, "{\n");
+	io.write_string(w, "{\n")
 	defer {
-		write_indent(fg, w);
-		io.write_string(w, "}");
+		write_indent(fg, w)
+		io.write_string(w, "}")
 	}
 
-	fg.depth += 1;
-	defer fg.depth -= 1;
+	fg.depth += 1
+	defer fg.depth -= 1
 
-	max_field_len := 0;
+	max_field_len := 0
 	for field_obj in struct_fields {
-		field := field_obj.(json.Object);
-		field_name := field["Name"].(string);
-		field_name = odin_keywords[field_name] or_else field_name;
+		field := field_obj.(json.Object)
+		field_name := field["Name"].(string)
+		field_name = odin_keywords[field_name] or_else field_name
 		if !is_field_anon(field) {
-			max_field_len = max(max_field_len, len(field_name));
+			max_field_len = max(max_field_len, len(field_name))
 		}
 	}
 
 	for field_obj in struct_fields {
-		field := field_obj.(json.Object);
-		field_name := field["Name"].(string);
-		field_name = odin_keywords[field_name] or_else field_name;
+		field := field_obj.(json.Object)
+		field_name := field["Name"].(string)
+		field_name = odin_keywords[field_name] or_else field_name
 
-		field_type := field["Type"].(json.Object);
-		field_attrs, _ := field["Attrs"].(json.Array);
-		write_indent(fg, w);
+		field_type := field["Type"].(json.Object)
+		field_attrs, _ := field["Attrs"].(json.Array)
+		write_indent(fg, w)
 
-		is_anon := is_field_anon(field);
+		is_anon := is_field_anon(field)
 		if is_anon {
-			io.write_string(w, "using _: ");
+			io.write_string(w, "using _: ")
 		} else {
-			io.write_string(w, field_name);
-			io.write_string(w, ": ");
-			for i in 0 ..< max_field_len-len(field_name) {
-				io.write_byte(w, ' ');
+			io.write_string(w, field_name)
+			io.write_string(w, ": ")
+			for i in 0 ..< max_field_len - len(field_name) {
+				io.write_byte(w, ' ')
 			}
 		}
 
-		field_options := parse_field_options(field_attrs);
+		field_options := parse_field_options(field_attrs)
 
-		write_type_ref(fg, w, field_type, field_options);
+		write_type_ref(fg, w, field_type, field_options)
 
-		io.write_string(w, ",\n");
+		io.write_string(w, ",\n")
 	}
 }
 
 is_return_type_void :: proc(return_type: json.Object) -> bool {
-	name, _ := return_type["Name"].(string);
-	return name == "Void";
+	name, _ := return_type["Name"].(string)
+	return name == "Void"
 }
 
 write_com :: proc(fg: ^File_Generator, w: io.Writer, obj: json.Object, name: string) {
-	assert(name != "");
+	assert(name != "")
 	if name == "placeholder_ignore_me" {
-		return;
+		return
 	}
 
-	arches, _ := obj["Architectures"].(json.Object);
+	arches, _ := obj["Architectures"].(json.Object)
 
 
-	com_optional_guid, _ := obj["Guid"].(string);
-	com_optional_iface, _ := obj["Interface"].(json.Object);
-	com_methods := obj["Methods"].(json.Array);
+	com_optional_guid, _ := obj["Guid"].(string)
+	com_optional_iface, _ := obj["Interface"].(json.Object)
+	com_methods := obj["Methods"].(json.Array)
 
 	if com_optional_guid != "" {
-		fmt.wprintf(w, "IID_%s_String :: %q;\n", name, com_optional_guid);
+		fmt.wprintf(w, "IID_%s_String :: %q;\n", name, com_optional_guid)
 
-		g, _ := strings.remove_all(com_optional_guid, "-", context.temp_allocator);
-		guid: [32]byte;
-		copy(guid[:], g);
-		str := string(guid[:]);
-		Data1, _ := strconv.parse_u64(str[0:][:8],  16);
-		Data2, _ := strconv.parse_u64(str[8:][:4],  16);
-		Data3, _ := strconv.parse_u64(str[12:][:4], 16);
-		Data4_slice := str[16:][:16];
-		Data4 := (^[8][2]u8)(raw_data(Data4_slice))^;
+		g, _ := strings.remove_all(com_optional_guid, "-", context.temp_allocator)
+		guid: [32]byte
+		copy(guid[:], g)
+		str := string(guid[:])
+		Data1, _ := strconv.parse_u64(str[0:][:8], 16)
+		Data2, _ := strconv.parse_u64(str[8:][:4], 16)
+		Data3, _ := strconv.parse_u64(str[12:][:4], 16)
+		Data4_slice := str[16:][:16]
+		Data4 := (^[8][2]u8)(raw_data(Data4_slice))^
 
 
-		fmt.wprintf(w, "IID_%s_Value  :: ", name);
+		fmt.wprintf(w, "IID_%s_Value  :: ", name)
 		if add_import(fg, BUILTIN_PKG) {
-			io.write_string(w, BUILTIN_PKG);
-			io.write_byte(w, '.');
+			io.write_string(w, BUILTIN_PKG)
+			io.write_byte(w, '.')
 		}
-		io.write_string(w, "GUID{");
-		fmt.wprintf(w, "0x%8x, 0x%4x, 0x%4x, ", Data1, Data2, Data3);
-		io.write_string(w, "{");
+		io.write_string(w, "GUID{")
+		fmt.wprintf(w, "0x%8x, 0x%4x, 0x%4x, ", Data1, Data2, Data3)
+		io.write_string(w, "{")
 		for _, i in Data4 {
 			if i > 0 {
-				io.write_string(w, ", ");
+				io.write_string(w, ", ")
 			}
-			value, _ := strconv.parse_u64(string(Data4[i][:]), 16);
-			fmt.wprintf(w, "0x%2x", value);
+			value, _ := strconv.parse_u64(string(Data4[i][:]), 16)
+			fmt.wprintf(w, "0x%2x", value)
 		}
 
-		io.write_string(w, "}");
-		io.write_string(w, "};\n");
+		io.write_string(w, "}")
+		io.write_string(w, "};\n")
 	}
 
-	fmt.wprintf(w, "%s :: struct ", name);
-	io.write_string(w, "{\n");
-	fmt.wprintf(w, "\tusing vtable: ^%s_Vtable,\n", name);
-	io.write_string(w, "}\n");
-	fmt.wprintf(w, "%s_Vtable :: struct ", name);
-	io.write_string(w, "{\n");
+	fmt.wprintf(w, "%s :: struct ", name)
+	io.write_string(w, "{\n")
+	fmt.wprintf(w, "\tusing vtable: ^%s_Vtable,\n", name)
+	io.write_string(w, "}\n")
+	fmt.wprintf(w, "%s_Vtable :: struct ", name)
+	io.write_string(w, "{\n")
 
 	// if com_optional_iface != nil {
 	// 	fmt.println(name, "->", com_optional_iface);
 	// }
 
-	method_conflicts: map[string]int;
-	defer delete(method_conflicts);
+	method_conflicts: map[string]int
+	defer delete(method_conflicts)
 
-	max_method_len := 0;
+	max_method_len := 0
 	for method_value in com_methods {
-		method_obj := method_value.(json.Object);
-		method_name := method_obj["Name"].(string);
+		method_obj := method_value.(json.Object)
+		method_name := method_obj["Name"].(string)
 		// TODO(bill): doesn't take into account conflicts but it'll be good enough for now
-		max_method_len = max(max_method_len, len(method_name));
+		max_method_len = max(max_method_len, len(method_name))
 	}
 
 	for method_value in com_methods {
-		method_obj := method_value.(json.Object);
-		method_name := method_obj["Name"].(string);
-		return_type := method_obj["ReturnType"].(json.Object);
-		params := method_obj["Params"].(json.Array);
+		method_obj := method_value.(json.Object)
+		method_name := method_obj["Name"].(string)
+		return_type := method_obj["ReturnType"].(json.Object)
+		params := method_obj["Params"].(json.Array)
 
-		count := method_conflicts[method_name];
-		method_conflicts[method_name] = count+1;
+		count := method_conflicts[method_name]
+		method_conflicts[method_name] = count + 1
 
-		padding_length := max_method_len-len(method_name);
+		padding_length := max_method_len - len(method_name)
 
-		fmt.wprintf(w, "\t%s", method_name);
+		fmt.wprintf(w, "\t%s", method_name)
 		if count != 0 {
-			suffix := fmt.tprintf("_v%d", count);
-			padding_length -= len(suffix);
-			fmt.wprintf(w, suffix);
+			suffix := fmt.tprintf("_v%d", count)
+			padding_length -= len(suffix)
+			fmt.wprintf(w, suffix)
 		}
-		io.write_string(w, ": ");
-		for i in 0..<padding_length {
-			io.write_byte(w, ' ');
+		io.write_string(w, ": ")
+		for i in 0 ..< padding_length {
+			io.write_byte(w, ' ')
 		}
-		io.write_string(w, "proc \"stdcall\" (");
-		fmt.wprintf(w, "self: ^%s", name);
+		io.write_string(w, "proc \"stdcall\" (")
+		fmt.wprintf(w, "self: ^%s", name)
 		for param_value, i in params {
-			param_obj := param_value.(json.Object);
-			param_name := param_obj["Name"].(string);
-			param_type := param_obj["Type"].(json.Object);
-			param_attrs, _ := param_obj["Attrs"].(json.Array);
-			assert(param_name != "");
+			param_obj := param_value.(json.Object)
+			param_name := param_obj["Name"].(string)
+			param_type := param_obj["Type"].(json.Object)
+			param_attrs, _ := param_obj["Attrs"].(json.Array)
+			assert(param_name != "")
 
-			param_name = odin_keywords[param_name] or_else param_name;
+			param_name = odin_keywords[param_name] or_else param_name
 
-			fmt.wprintf(w, ", %s: ", param_name);
-			field_options := parse_field_options(param_attrs);
-			write_type_ref(fg, w, param_type, field_options);
+			fmt.wprintf(w, ", %s: ", param_name)
+			field_options := parse_field_options(param_attrs)
+			write_type_ref(fg, w, param_type, field_options)
 		}
 
-		io.write_string(w, ")");
+		io.write_string(w, ")")
 
 		if !is_return_type_void(return_type) {
-			io.write_string(w, " -> ");
-			write_type_ref(fg, w, return_type, nil);
+			io.write_string(w, " -> ")
+			write_type_ref(fg, w, return_type, nil)
 		}
 
-		io.write_string(w, ",\n");
+		io.write_string(w, ",\n")
 	}
 
-	io.write_string(w, "}\n");
+	io.write_string(w, "}\n")
 
 
 }
 
-write_type :: proc(fg: ^File_Generator, w: io.Writer, type: json.Value, originally_from_comment := "") {
-	obj := type.(json.Object);
-	name := obj["Name"].(string);
-	kind := obj["Kind"].(string);
-	arches, _ := obj["Architectures"].(json.Object);
+write_type :: proc(
+	fg: ^File_Generator,
+	w: io.Writer,
+	type: json.Value,
+	originally_from_comment := "",
+) {
+	obj := type.(json.Object)
+	name := obj["Name"].(string)
+	kind := obj["Kind"].(string)
+	arches, _ := obj["Architectures"].(json.Object)
 
 	if kind == "ComClassID" {
-		return;
+		return
 	}
 
 	if get_anon_kind(name) != .None {
-		return;
+		return
 	}
 
 	if (Api_Ref{fg.file.api, name}) in fg.g.type_names_to_remove {
-		return;
+		return
 	}
 
 	if name in fg.all_decls {
-		return;
+		return
 	}
-	fg.all_decls[name] = true;
+	fg.all_decls[name] = true
 
 	if originally_from_comment != "" {
-		io.write_string(w, "// Type originally from ");
-		io.write_string(w, originally_from_comment);
-		io.write_string(w, "\n");
+		io.write_string(w, "// Type originally from ")
+		io.write_string(w, originally_from_comment)
+		io.write_string(w, "\n")
 	}
 
 	if fg.is_types_pkg {
-		fg.g.type_in_pkg_types[name] = true;
+		fg.g.type_in_pkg_types[name] = true
 	}
 
 	if name in types_that_conflict_with_consts {
-		io.write_string(w, "// Warning: this type conflicts with a constant\n");
-		fmt.wprintf(w, "%s__CONFLICT :: struct{{}};\n", name);
-		return;
+		io.write_string(w, "// Warning: this type conflicts with a constant\n")
+		fmt.wprintf(w, "%s__CONFLICT :: struct{{}};\n", name)
+		return
 	}
 	if name in types_to_skip {
-		io.write_string(w, "// Warning: type has not been generated due to an error\n");
+		io.write_string(w, "// Warning: type has not been generated due to an error\n")
 		if kind == "FunctionPointer" {
-			fmt.wprintf(w, "%s :: distinct rawptr;\n", name);
+			fmt.wprintf(w, "%s :: distinct rawptr;\n", name)
 		} else {
-			fmt.wprintf(w, "%s :: struct{{}};\n", name);
+			fmt.wprintf(w, "%s :: struct{{}};\n", name)
 		}
-		return;
+		return
 	}
 
 	if !fg.is_types_pkg {
-		assert(add_import(fg, TYPES_PKG));
-		fmt.wprintf(w, "%s :: %s.%s;\n", name, TYPES_PKG, name);
-		return;
+		assert(add_import(fg, TYPES_PKG))
+		fmt.wprintf(w, "%s :: %s.%s;\n", name, TYPES_PKG, name)
+		return
 	}
 
 
 	defer {
-		io.write_byte(w, '\n');
+		io.write_byte(w, '\n')
 	}
 
 
 	if (Api_Ref{fg.file.api, name} in fg.g.api_cycle_type_set) {
 		if add_import(fg, BUILTIN_PKG) {
-			fmt.wprintf(w, "%s :: %s.%s;\n", name, BUILTIN_PKG, name);
-			return;
+			fmt.wprintf(w, "%s :: %s.%s;\n", name, BUILTIN_PKG, name)
+			return
 		}
 	}
 
@@ -649,154 +679,154 @@ write_type :: proc(fg: ^File_Generator, w: io.Writer, type: json.Value, original
 	case "NativeTypedef":
 		switch name {
 		case "PSTR":
-			io.write_string(w, "PSTR :: cstring;\n");
-			return;
+			io.write_string(w, "PSTR :: cstring;\n")
+			return
 		case "PWSTR":
-			io.write_string(w, "PWSTR :: ^u16;\n");
-			return;
+			io.write_string(w, "PWSTR :: ^u16;\n")
+			return
 		case "BOOL":
-			io.write_string(w, "BOOL :: distinct b32;\n");
-			return;
+			io.write_string(w, "BOOL :: distinct b32;\n")
+			return
 		}
 
 
-		def := obj["Def"].(json.Object);
-		also_usable_for := obj["AlsoUsableFor"];
+		def := obj["Def"].(json.Object)
+		also_usable_for := obj["AlsoUsableFor"]
 
 		#partial switch alias_name in also_usable_for {
 		case json.Null:
-			// Okay
+		// Okay
 		case string:
 			if api, ok := also_usable_type_api_map[alias_name]; ok {
-				api_pkg := fg.g.api_to_pkg_map[api];
-				assert(api_pkg != nil);
+				api_pkg := fg.g.api_to_pkg_map[api]
+				assert(api_pkg != nil)
 				if api_pkg != fg.file.pkg {
-					fg.imports[api_pkg.name] = true;
-					fmt.wprintf(w, "%s :: %s.%s;\n", name, api_pkg.name, alias_name);
+					fg.imports[api_pkg.name] = true
+					fmt.wprintf(w, "%s :: %s.%s;\n", name, api_pkg.name, alias_name)
 				} else {
-					fmt.wprintf(w, "%s :: %s;\n", name, alias_name);
+					fmt.wprintf(w, "%s :: %s;\n", name, alias_name)
 				}
-				return;
+				return
 			}
 
-			fmt.panicf("Invalid also_usable_for type: %s :: %s;", name, alias_name);
+			fmt.panicf("Invalid also_usable_for type: %s :: %s;", name, alias_name)
 		case:
-			panic("Invalid also_usable_for type");
+			panic("Invalid also_usable_for type")
 		}
 
 		if name in handle_types {
-			fmt.wprintf(w, "%s :: distinct rawptr;\n", name);
-			return;
+			fmt.wprintf(w, "%s :: distinct rawptr;\n", name)
+			return
 		}
 
-		fmt.wprintf(w, "%s :: distinct ", name);
-		write_type_ref(fg, w, def, nil);
-		io.write_string(w, ";\n");
+		fmt.wprintf(w, "%s :: distinct ", name)
+		write_type_ref(fg, w, def, nil)
+		io.write_string(w, ";\n")
 
 
 	case "Enum":
-		values := obj["Values"].(json.Array);
-		integer_base, _ := obj["IntegerBase"].(string);
-		fmt.wprintf(w, "%s :: enum ", name);
-		is_unsigned := false;
+		values := obj["Values"].(json.Array)
+		integer_base, _ := obj["IntegerBase"].(string)
+		fmt.wprintf(w, "%s :: enum ", name)
+		is_unsigned := false
 		// TODO(bill): integer base type
 		switch integer_base {
 		case "Int16":
-			io.write_string(w, "i16 {\n");
+			io.write_string(w, "i16 {\n")
 		case "UInt16":
-			io.write_string(w, "u16 {\n");
-			is_unsigned = true;
+			io.write_string(w, "u16 {\n")
+			is_unsigned = true
 		case "Int32":
-			io.write_string(w, "i32 {\n");
+			io.write_string(w, "i32 {\n")
 		case "UInt32":
-			io.write_string(w, "u32 {\n");
-			is_unsigned = true;
+			io.write_string(w, "u32 {\n")
+			is_unsigned = true
 		case "Int64":
-			io.write_string(w, "i64 {\n");
+			io.write_string(w, "i64 {\n")
 		case "UInt64":
-			io.write_string(w, "u64 {\n");
-			is_unsigned = true;
+			io.write_string(w, "u64 {\n")
+			is_unsigned = true
 		case "":
-			fg.imports["core:c"] = true;
-			io.write_string(w, "c.int {\n");
+			fg.imports["core:c"] = true
+			io.write_string(w, "c.int {\n")
 		case:
-			panic(integer_base);
+			panic(integer_base)
 		}
 
-		max_len := 0;
+		max_len := 0
 		for value in values {
-			obj := value.(json.Object);
-			k := obj["Name"].(string);
-			max_len = max(len(k), max_len);
+			obj := value.(json.Object)
+			k := obj["Name"].(string)
+			max_len = max(len(k), max_len)
 		}
 		for value in values {
-			obj := value.(json.Object);
-			k := obj["Name"].(string);
-			v := obj["Value"].(i64);
-			fmt.wprintf(w, "\t%s ", k);
-			for i in 0..<max_len - len(k) {
-				io.write_byte(w, ' ');
+			obj := value.(json.Object)
+			k := obj["Name"].(string)
+			v := obj["Value"].(i64)
+			fmt.wprintf(w, "\t%s ", k)
+			for i in 0 ..< max_len - len(k) {
+				io.write_byte(w, ' ')
 			}
 			if is_unsigned {
-				fmt.wprintf(w, "= %v,\n", u64(v));
+				fmt.wprintf(w, "= %v,\n", u64(v))
 			} else {
-				fmt.wprintf(w, "= %v,\n", v);
+				fmt.wprintf(w, "= %v,\n", v)
 			}
 		}
 
-		io.write_string(w, "}\n");
+		io.write_string(w, "}\n")
 	case "Struct":
-		io.write_string(w, name);
-		io.write_string(w, " :: ");
-		write_struct_or_union(fg, w, obj, name, .Struct);
-		io.write_string(w, "\n");
+		io.write_string(w, name)
+		io.write_string(w, " :: ")
+		write_struct_or_union(fg, w, obj, name, .Struct)
+		io.write_string(w, "\n")
 	case "Union":
-		io.write_string(w, name);
-		io.write_string(w, " :: ");
-		write_struct_or_union(fg, w, obj, name, .Union);
-		io.write_string(w, "\n");
+		io.write_string(w, name)
+		io.write_string(w, " :: ")
+		write_struct_or_union(fg, w, obj, name, .Union)
+		io.write_string(w, "\n")
 
 	case "Com":
-		write_com(fg, w, obj, name);
+		write_com(fg, w, obj, name)
 
 	case "FunctionPointer":
-		return_type, _ := obj["ReturnType"].(json.Object);
-		params, _ := obj["Params"].(json.Array);
+		return_type, _ := obj["ReturnType"].(json.Object)
+		params, _ := obj["Params"].(json.Array)
 
-		fmt.wprintf(w, "%s :: proc \"stdcall\" (", name);
+		fmt.wprintf(w, "%s :: proc \"stdcall\" (", name)
 
 		for param_value, i in params {
-			param_obj := param_value.(json.Object);
-			param_name := param_obj["Name"].(string);
-			param_type := param_obj["Type"].(json.Object);
-			param_attrs, _ := param_obj["Attrs"].(json.Array);
-			assert(param_name != "");
+			param_obj := param_value.(json.Object)
+			param_name := param_obj["Name"].(string)
+			param_type := param_obj["Type"].(json.Object)
+			param_attrs, _ := param_obj["Attrs"].(json.Array)
+			assert(param_name != "")
 			if i > 0 {
-				io.write_string(w, ", ");
+				io.write_string(w, ", ")
 			}
-			param_name = odin_keywords[param_name] or_else param_name;
+			param_name = odin_keywords[param_name] or_else param_name
 
-			fmt.wprintf(w, "%s: ", param_name);
-			field_options := parse_field_options(param_attrs);
-			write_type_ref(fg, w, param_type, field_options);
+			fmt.wprintf(w, "%s: ", param_name)
+			field_options := parse_field_options(param_attrs)
+			write_type_ref(fg, w, param_type, field_options)
 		}
 
-		io.write_string(w, ")");
+		io.write_string(w, ")")
 
 		if !is_return_type_void(return_type) {
-			io.write_string(w, " -> ");
-			write_type_ref(fg, w, return_type, nil);
+			io.write_string(w, " -> ")
+			write_type_ref(fg, w, return_type, nil)
 		}
 
-		io.write_string(w, ";\n");
+		io.write_string(w, ";\n")
 	case:
-		panic(kind);
+		panic(kind)
 	}
 
 	for nested_type in fg.nested_types_to_print {
-		write_type(fg, w, nested_type);
+		write_type(fg, w, nested_type)
 	}
-	clear(&fg.nested_types_to_print);
+	clear(&fg.nested_types_to_print)
 }
 
 File_Kind :: enum {
@@ -807,329 +837,323 @@ File_Kind :: enum {
 
 
 write_proc :: proc(fg: ^File_Generator, w: io.Writer, procedure: json.Value) {
-	obj := procedure.(json.Object);
-	name := obj["Name"].(string);
-	return_type, _ := obj["ReturnType"].(json.Object);
-	params, _ := obj["Params"].(json.Array);
+	obj := procedure.(json.Object)
+	name := obj["Name"].(string)
+	return_type, _ := obj["ReturnType"].(json.Object)
+	params, _ := obj["Params"].(json.Array)
 
-	fmt.wprintf(w, "\t%s :: proc(", name);
+	fmt.wprintf(w, "\t%s :: proc(", name)
 
 	for param_value, i in params {
-		param_obj := param_value.(json.Object);
-		param_name := param_obj["Name"].(string);
-		param_type := param_obj["Type"].(json.Object);
-		param_attrs, _ := param_obj["Attrs"].(json.Array);
-		assert(param_name != "");
+		param_obj := param_value.(json.Object)
+		param_name := param_obj["Name"].(string)
+		param_type := param_obj["Type"].(json.Object)
+		param_attrs, _ := param_obj["Attrs"].(json.Array)
+		assert(param_name != "")
 		if i > 0 {
-			io.write_string(w, ", ");
+			io.write_string(w, ", ")
 		}
-		param_name = odin_keywords[param_name] or_else param_name;
+		param_name = odin_keywords[param_name] or_else param_name
 
-		fmt.wprintf(w, "%s: ", param_name);
-		field_options := parse_field_options(param_attrs);
-		write_type_ref(fg, w, param_type, field_options);
+		fmt.wprintf(w, "%s: ", param_name)
+		field_options := parse_field_options(param_attrs)
+		write_type_ref(fg, w, param_type, field_options)
 	}
 
-	io.write_string(w, ")");
+	io.write_string(w, ")")
 
 	if !is_return_type_void(return_type) {
-		io.write_string(w, " -> ");
-		write_type_ref(fg, w, return_type, nil);
+		io.write_string(w, " -> ")
+		write_type_ref(fg, w, return_type, nil)
 	}
 
-	io.write_string(w, " ---\n");
+	io.write_string(w, " ---\n")
 }
 
 path_to_identifier :: proc(path: string) -> string {
-	buf := make([]byte, len(path));
-	copy(buf, path);
+	buf := make([]byte, len(path))
+	copy(buf, path)
 	for c, i in buf {
 		switch c {
 		case '-', '.':
-			buf[i] = '_';
+			buf[i] = '_'
 		}
 	}
-	return string(buf);
+	return string(buf)
 }
 
 generate_file :: proc(using fg: ^File_Generator, file_kind: File_Kind) {
-	fmt.printf("Generating: %s\n", fg.fullpath);
-	strings.reset_builder(b);
-	w := strings.to_writer(b);
+	fmt.printf("Generating: %s\n", fg.fullpath)
+	strings.builder_reset(b)
+	w := strings.to_writer(b)
 
-	root := file.root.(json.Object);
+	root := file.root.(json.Object)
 
 	switch file_kind {
 	case .Constants:
-		constants, _ := root["Constants"].(json.Array);
-		fmt.wprintln(w, "\n");
+		constants, _ := root["Constants"].(json.Array)
+		fmt.wprintln(w, "\n")
 		for constant in constants {
-			write_constant(fg, w, constant);
+			write_constant(fg, w, constant)
 		}
 
 	case .Types:
-		types, _ := root["Types"].(json.Array);
+		types, _ := root["Types"].(json.Array)
 		for type in types {
-			write_type(fg, w, type);
+			write_type(fg, w, type)
 		}
 
 	case .Procedures:
-		functions, _ := root["Functions"].(json.Array);
+		functions, _ := root["Functions"].(json.Array)
 
 		for func in functions {
-			obj := func.(json.Object);
-			dll_import := obj["DllImport"].(string);
-			name := obj["Name"].(string);
+			obj := func.(json.Object)
+			dll_import := obj["DllImport"].(string)
+			name := obj["Name"].(string)
 
-			proc_ref := Api_Ref{file.api, name};
+			proc_ref := Api_Ref{file.api, name}
 			if proc_ref in g.procedures_to_ignore {
-				continue;
+				continue
 			}
 
 			if dll_import not_in foreign_imports {
-				foreign_imports[dll_import] = path_to_identifier(dll_import);
-				fg.procedures[dll_import] = new_clone(Grouped_Procedures{dll_import = dll_import});
+				foreign_imports[dll_import] = path_to_identifier(dll_import)
+				fg.procedures[dll_import] = new_clone(Grouped_Procedures{dll_import = dll_import})
 			}
-			append(&fg.procedures[dll_import].procedures, func);
+			append(&fg.procedures[dll_import].procedures, func)
 		}
 
 		for dll_import, gp in fg.procedures {
-			fmt.wprintln(w, "\n");
-			fmt.wprintln(w, "@(default_calling_convention=\"stdcall\")");
-			fmt.wprintf(w, "foreign %s {{\n", foreign_imports[dll_import]);
+			fmt.wprintln(w, "\n")
+			fmt.wprintln(w, "@(default_calling_convention=\"stdcall\")")
+			fmt.wprintf(w, "foreign %s {{\n", foreign_imports[dll_import])
 			for procedure in gp.procedures {
-				write_proc(fg, w, procedure);
+				write_proc(fg, w, procedure)
 			}
-			fmt.wprintln(w, "}\n");
+			fmt.wprintln(w, "}\n")
 		}
 
 	}
 
-	fmt.fprintln(fd, "// This code was generated; DO NOT EDIT.\n");
+	fmt.fprintln(fd, "// This code was generated; DO NOT EDIT.\n")
 
-	fmt.fprintln(fd, "//+build windows");
-	fmt.fprintln(fd, "//+lazy");
-	fmt.fprintf(fd, "package win32_%s\n", file.pkg.name);
+	fmt.fprintln(fd, "//+build windows")
+	fmt.fprintln(fd, "//+lazy")
+	fmt.fprintf(fd, "package win32_%s\n", file.pkg.name)
 
-	import_count := 0;
+	import_count := 0
 	for import_path in imports {
 		if import_path == file.pkg.name {
-			continue;
+			continue
 		}
 		if import_count == 0 {
-			fmt.fprintf(fd, "\n");
+			fmt.fprintf(fd, "\n")
 		}
 		if strings.has_prefix(import_path, "core:") {
-			fmt.fprintf(fd, "import \"%s\"\n", import_path);
+			fmt.fprintf(fd, "import \"%s\"\n", import_path)
 		} else {
-			fmt.fprintf(fd, "import %s \"../%s\"\n", import_path, import_path);
+			fmt.fprintf(fd, "import %s \"../%s\"\n", import_path, import_path)
 		}
-		import_count += 1;
+		import_count += 1
 	}
 	if import_count != 0 {
-		fmt.fprintf(fg.fd, "\n");
+		fmt.fprintf(fg.fd, "\n")
 	}
-	import_count = 0;
+	import_count = 0
 	for lib, ident in foreign_imports {
-		fmt.fprintf(fd, "foreign import %s \"system:%s.lib\"\n", ident, lib);
+		fmt.fprintf(fd, "foreign import %s \"system:%s.lib\"\n", ident, lib)
 	}
 	if import_count != 0 {
-		fmt.fprintf(fg.fd, "\n");
+		fmt.fprintf(fg.fd, "\n")
 	}
 
 
-	os.write(fd, b.buf[:]);
+	os.write(fd, b.buf[:])
 }
 
 generate_file_of_types :: proc(fg: ^File_Generator) {
-	fmt.printf("Generating: %s\n", fg.fullpath);
-	strings.reset_builder(fg.b);
-	w := strings.to_writer(fg.b);
+	fmt.printf("Generating: %s\n", fg.fullpath)
+	strings.builder_reset(fg.b)
+	w := strings.to_writer(fg.b)
 
-	assert(fg.file != nil);
-	root := fg.file.root.(json.Object);
-	constants, _ := root["Constants"].(json.Array);
-	types,     _ := root["Types"].(json.Array);
-	functions, _ := root["Functions"].(json.Array);
+	assert(fg.file != nil)
+	root := fg.file.root.(json.Object)
+	constants, _ := root["Constants"].(json.Array)
+	types, _ := root["Types"].(json.Array)
+	functions, _ := root["Functions"].(json.Array)
 
 	for type in types {
-		write_type(fg, w, type);
+		write_type(fg, w, type)
 	}
 
-	fmt.fprintln(fg.fd, "// This code was generated; DO NOT EDIT.\n");
+	fmt.fprintln(fg.fd, "// This code was generated; DO NOT EDIT.\n")
 
-	fmt.fprintln(fg.fd, "//+build windows");
-	fmt.fprintln(fg.fd, "//+lazy");
-	fmt.fprintln(fg.fd, "package win32__types\n");
+	fmt.fprintln(fg.fd, "//+build windows")
+	fmt.fprintln(fg.fd, "//+lazy")
+	fmt.fprintln(fg.fd, "package win32__types\n")
 
 
-	import_count := 0;
+	import_count := 0
 	for import_path in fg.imports {
 		if import_path == fg.file.pkg.name {
-			continue;
+			continue
 		}
 		if import_count == 0 {
-			fmt.fprintf(fg.fd, "\n");
+			fmt.fprintf(fg.fd, "\n")
 		}
 		if strings.has_prefix(import_path, "core:") {
-			fmt.fprintf(fg.fd, "import \"%s\"\n", import_path);
+			fmt.fprintf(fg.fd, "import \"%s\"\n", import_path)
 		} else {
-			fmt.fprintf(fg.fd, "import %s \"../%s\"\n", import_path, import_path);
+			fmt.fprintf(fg.fd, "import %s \"../%s\"\n", import_path, import_path)
 		}
-		import_count += 1;
+		import_count += 1
 	}
 
 	if import_count != 0 {
-		fmt.fprintf(fg.fd, "\n");
+		fmt.fprintf(fg.fd, "\n")
 	}
 
 
-	os.write(fg.fd, fg.b.buf[:]);
+	os.write(fg.fd, fg.b.buf[:])
 }
 
 write_to_odin :: proc(g: ^Generator) {
-	file_builder := strings.make_builder();
+	file_builder := strings.builder_make()
 
-	base_dir := "win32odin-v2";
-	os.make_directory(base_dir, 0);
 
-	os.make_directory(fmt.tprintf("%s", base_dir), 0);
+	base_dir := "win32odin-v2"
+	os.make_directory(base_dir, 0)
 
-	missing_clr_types := make(map[string]json.Object);
-	defer delete(missing_clr_types);
+	os.make_directory(fmt.tprintf("%s", base_dir), 0)
 
-	{ // package types
-		pkg_name := "_types";
-		os.make_directory(fmt.tprintf("%s/%s", base_dir, pkg_name), 0);
+	missing_clr_types := make(map[string]json.Object)
+	defer delete(missing_clr_types)
 
-		all_decls := make(map[string]bool);
-		defer delete(all_decls);
+	{ 	// package types
+		pkg_name := "_types"
+		os.make_directory(fmt.tprintf("%s/%s", base_dir, pkg_name), 0)
+
+		all_decls := make(map[string]bool)
+		defer delete(all_decls)
 
 		for _, pkg in g.pkgs {
 			for file in pkg.files {
 				if g.apis_not_needed_for_types[file.api] {
-					continue;
+					continue
 				}
 
-				file_name := file.name;
+				file_name := file.name
 				// NOTE(bill): prevent the `*_linux.odin` problem
 				if strings.has_suffix(file_name, "_linux") {
-					file_name = strings.concatenate({file_name, "os"});
+					file_name = strings.concatenate({file_name, "os"})
 				}
 
-				path := fmt.aprintf("%s/%s/%s_%s.odin", base_dir, pkg_name, pkg.name, file_name);
-				defer delete(path);
-				f, err := os.open(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0);
-				assert(err == 0);
-				defer os.close(f);
+				path := fmt.aprintf("%s/%s/%s_%s.odin", base_dir, pkg_name, pkg.name, file_name)
+				defer delete(path)
+				f, err := os.open(path, os.O_WRONLY | os.O_CREATE | os.O_TRUNC, 0)
+				assert(err == 0)
+				defer os.close(f)
 				file_gen := &File_Generator{
-					g    = g,
-					fd   = f,
-					b    = &file_builder,
+					g = g,
+					fd = f,
+					b = &file_builder,
 					file = file,
 					fullpath = path,
 					ignore_imports = true,
 					is_types_pkg = true,
 					all_decls = &all_decls,
 					missing_clr_types = &missing_clr_types,
-				};
-				defer delete(file_gen.nested_types_to_print);
-				generate_file_of_types(file_gen);
+				}
+				defer delete(file_gen.nested_types_to_print)
+				generate_file_of_types(file_gen)
 			}
 		}
 	}
 
 
 	if false do for _, pkg in g.pkgs {
-		os.make_directory(fmt.tprintf("%s/%s", base_dir, pkg.name), 0);
+		os.make_directory(fmt.tprintf("%s/%s", base_dir, pkg.name), 0)
 		for file in pkg.files {
-			root := file.root.(json.Object);
+			root := file.root.(json.Object)
 
 			for file_kind in File_Kind {
-				@static suffixes := [File_Kind]string{
+				@(static)
+				suffixes := [File_Kind]string {
 					.Constants  = "consts",
 					.Types      = "types",
 					.Procedures = "procs",
-				};
-				@static root_array := [File_Kind]string{
+				}
+				@(static)
+				root_array := [File_Kind]string {
 					.Constants  = "Constants",
 					.Types      = "Types",
 					.Procedures = "Functions",
-				};
+				}
 
-				suffix := suffixes[file_kind];
+				suffix := suffixes[file_kind]
 				if entities, _ := root[root_array[file_kind]].(json.Array); len(entities) == 0 {
-					continue;
+					continue
 				}
 
-				all_decls := make(map[string]bool);
-				defer delete(all_decls);
+				all_decls := make(map[string]bool)
+				defer delete(all_decls)
 
-				path := fmt.tprintf("%s/%s/%s_%s.odin", base_dir, pkg.name, file.name, suffix);
-				f, err := os.open(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0);
-				assert(err == 0);
-				defer os.close(f);
-				file_gen := &File_Generator{
-					g    = g,
-					fd   = f,
-					b    = &file_builder,
-					fullpath = path,
-					file = file,
-					all_decls = &all_decls,
-					disallow_maybe = true,
-					missing_clr_types = &missing_clr_types,
-				};
-				generate_file(file_gen, file_kind);
-				delete(file_gen.imports);
+				path := fmt.tprintf("%s/%s/%s_%s.odin", base_dir, pkg.name, file.name, suffix)
+				f, err := os.open(path, os.O_WRONLY | os.O_CREATE | os.O_TRUNC, 0)
+				assert(err == 0)
+				defer os.close(f)
+				file_gen := &File_Generator{g = g, fd = f, b = &file_builder, fullpath = path, file = file, all_decls = &all_decls, disallow_maybe = true, missing_clr_types = &missing_clr_types}
+				generate_file(file_gen, file_kind)
+				delete(file_gen.imports)
 				for _, ident in file_gen.foreign_imports {
-					delete(ident);
+					delete(ident)
 				}
-				delete(file_gen.foreign_imports);
+				delete(file_gen.foreign_imports)
 				for _, g in file_gen.procedures {
-					delete(g.procedures);
-					free(g);
+					delete(g.procedures)
+					free(g)
 				}
-				delete(file_gen.procedures);
+				delete(file_gen.procedures)
 			}
 		}
 	}
 
-	if false { // package builtin
-		pkg_name := BUILTIN_PKG;
-		os.make_directory(fmt.tprintf("%s/%s", base_dir, pkg_name), 0);
+	if false { 	// package builtin
+		pkg_name := BUILTIN_PKG
+		os.make_directory(fmt.tprintf("%s/%s", base_dir, pkg_name), 0)
 
-		path := fmt.aprintf("%s/%s/builtin_types.odin", base_dir, pkg_name);
-		defer delete(path);
-		f, err := os.open(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0);
-		assert(err == 0);
-		defer os.close(f);
+		path := fmt.aprintf("%s/%s/builtin_types.odin", base_dir, pkg_name)
+		defer delete(path)
+		f, err := os.open(path, os.O_WRONLY | os.O_CREATE | os.O_TRUNC, 0)
+		assert(err == 0)
+		defer os.close(f)
 
-		strings.reset_builder(&file_builder);
-		w := strings.to_writer(&file_builder);
+		strings.builder_reset(&file_builder)
+		w := strings.to_writer(&file_builder)
 
-		fmt.wprintln(w, "// This code was generated; DO NOT EDIT.\n");
+		fmt.wprintln(w, "// This code was generated; DO NOT EDIT.\n")
 
-		fmt.wprintln(w, "//+build windows");
-		fmt.wprintln(w, "//+lazy");
-		fmt.wprintln(w, "package win32__builtin\n");
+		fmt.wprintln(w, "//+build windows")
+		fmt.wprintln(w, "//+lazy")
+		fmt.wprintln(w, "package win32__builtin\n")
 
-		fmt.wprintln(w, "GUID :: struct {");
-		fmt.wprintln(w, "\tData1: u32,");
-		fmt.wprintln(w, "\tData2: u16,");
-		fmt.wprintln(w, "\tData3: u16,");
-		fmt.wprintln(w, "\tData4: [8]u8,");
-		fmt.wprintln(w, "}\n");
+		fmt.wprintln(w, "GUID :: struct {")
+		fmt.wprintln(w, "\tData1: u32,")
+		fmt.wprintln(w, "\tData2: u16,")
+		fmt.wprintln(w, "\tData3: u16,")
+		fmt.wprintln(w, "\tData4: [8]u8,")
+		fmt.wprintln(w, "}\n")
 
 
 		if len(missing_clr_types) != 0 {
-			fmt.wprintln(w, "// Missing CLR Types\n");
+			fmt.wprintln(w, "// Missing CLR Types\n")
 
 			for name, missing_clr_type in missing_clr_types {
-				fmt.wprintf(w, "%s :: struct {{rawptr}};\n", name);
+				fmt.wprintf(w, "%s :: struct {{rawptr}};\n", name)
 			}
 		}
 
-		os.write(f, file_builder.buf[:]);
+		os.write(f, file_builder.buf[:])
 	}
 }
 
@@ -1146,7 +1170,7 @@ types_to_skip := map[string]bool {
 	"VDMGLOBALNEXTPROC"                         = true,
 	"VDMMODULEFIRSTPROC"                        = true,
 	"VDMMODULENEXTPROC"                         = true,
-};
+}
 
 
 types_that_conflict_with_consts := map[string]bool {
@@ -1166,7 +1190,7 @@ types_that_conflict_with_consts := map[string]bool {
 	"AE_NETLOGON"     = true,
 	"AE_NETLOGOFF"    = true,
 	"AE_LOCKOUT"      = true,
-};
+}
 
 
 also_usable_type_api_map := map[string]string {
@@ -1175,9 +1199,9 @@ also_usable_type_api_map := map[string]string {
 	"HICON"      = "UI.WindowsAndMessaging",
 	"HANDLE"     = "System.SystemServices",
 	"HeapHandle" = "System.SystemServices",
-};
+}
 
-handle_types := map[string]bool{
+handle_types := map[string]bool {
 	"HANDLE"                   = true,
 	"SOCKET"                   = true,
 	"HICON"                    = true,
@@ -1284,4 +1308,5 @@ handle_types := map[string]bool{
 	"PSID"                     = true,
 	"AUTHZ_AUDIT_EVENT_HANDLE" = true,
 	"HeapHandle"               = true,
-};
+}
+


### PR DESCRIPTION
This commit makes the code work with odin dev-2023-09:c23b5825.

Some procs have been renamed in the stdlib:

> strings.make_builder  -> strings.builder_make
> strings.reset_builder -> strings.builder_reset

Additionally, auto-formatting removes semicolons and re-organizes imports.